### PR TITLE
Error linter when ES6+ syntax is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
   },
   "eslintConfig": {
     "root": true,
+    "parserOptions": {
+      "ecmaVersion": 5
+    },
     "env": {
       "browser": true,
       "jasmine": true,


### PR DESCRIPTION
Automatically ban ES6+ syntax from the application (needed for continuing IE support)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
